### PR TITLE
ci: change checkout action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Descrição

This pull request includes updates to the GitHub Actions workflow in the `.github/workflows/ci.yml` file. The changes involve upgrading the version of the `actions/checkout` action from v3 to v4 in multiple job definitions.

The update refers to use Node.js version 20 instead version 16, which is deprecated. 

---

## Tipo da alteração

ci: Alterações nos arquivos e scripts de configuração do CI

<!-- USE A OPÇÃO MAIS RELEVANTE
feat: Uma nova funcionalidade
fix: Correção de algum bug
style: Alterações que não afetam o significado do código (espaço em branco, formatação etc.)
perf: Mudança no código para melhoria de performance
refactor: Uma alteração de código que não corrige um bug nem adiciona um recurso
test: Adicionando testes ausentes ou corrigindo testes existentes
build: Alterações que afetam o sistema de compilação ou dependências externas
ci: Alterações nos arquivos e scripts de configuração do CI'
chore: Outras alterações que não modificam os arquivos de origem ou de teste
docs: Apenas mudança de documentação
revert: Reverte um commit
wip: Código em desenvolvimento
-->

---

## Checklist

<!-- Verifique as opções relacionadas a você. -->

- [x] Revi meu próprio código antes de enviar para revisão
- [x] Testei minha correção ou recurso extensivamente antes de enviar para revisão
- [x] Formatei meu código usando o guia de estilo de interface (Prettier + ESLint)
- [x] Meu código está bem documentado com apenas informações relevantes
- [x] Minhas alterações não geram novos avisos
- [x] Meus commits são bem organizados, descritivos e fáceis de reverter

---

## Outras observações

<!-- Inclua outras observações relevantes que não se enquadram nos campos acima -->

---
