### PR TITLE
chore: do not run husky on merge commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+# Runs lint staged only if it is not a merge commit
+git rev-parse -q --no-revs --verify MERGE_HEAD || npx lint-staged


### PR DESCRIPTION
## Descrição

This pull request includes a change to the `.husky/pre-commit` file. The change ensures that `lint-staged` is only run if it is **not a merge commit**. This is done by using `git rev-parse` to verify if `MERGE_HEAD` exists, which indicates that it's a merge commit. If `MERGE_HEAD` does not exist, `lint-staged` is run. This is a useful change as it prevents unnecessary linting during merge commits.

---

## Tipo da alteração

chore: Outras alterações que não modificam os arquivos de origem ou de teste

<!-- USE A OPÇÃO MAIS RELEVANTE
feat: Uma nova funcionalidade
fix: Correção de algum bug
style: Alterações que não afetam o significado do código (espaço em branco, formatação etc.)
perf: Mudança no código para melhoria de performance
refactor: Uma alteração de código que não corrige um bug nem adiciona um recurso
test: Adicionando testes ausentes ou corrigindo testes existentes
build: Alterações que afetam o sistema de compilação ou dependências externas
ci: Alterações nos arquivos e scripts de configuração do CI'
chore: Outras alterações que não modificam os arquivos de origem ou de teste
docs: Apenas mudança de documentação
revert: Reverte um commit
wip: Código em desenvolvimento
-->

---

## Checklist

<!-- Verifique as opções relacionadas a você. -->

- [x] Revi meu próprio código antes de enviar para revisão
- [x] Testei minha correção ou recurso extensivamente antes de enviar para revisão
- [x] Formatei meu código usando o guia de estilo de interface (Prettier + ESLint)
- [x] Meu código está bem documentado com apenas informações relevantes
- [x] Minhas alterações não geram novos avisos
- [x] Meus commits são bem organizados, descritivos e fáceis de reverter

---

## Outras observações

<!-- Inclua outras observações relevantes que não se enquadram nos campos acima -->

---
